### PR TITLE
Fix packer instructions in the README

### DIFF
--- a/README.org
+++ b/README.org
@@ -52,7 +52,7 @@ use {
   config = function ()
     require("orgmode-babel").setup({
       -- by default, none are enabled
-      langs = { "python", "lua", ... }
+      langs = { "python", "lua", "nix" },
 
       -- paths to emacs packages to additionally load
       load_paths = {}


### PR DESCRIPTION
In continuation of this: https://github.com/mrshmllow/orgmode-babel.nvim/issues/1.